### PR TITLE
Escalate privileges for extracting tarball and setting alternatives

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -99,6 +99,7 @@
         path: "{{ java_install_dir }}/{{ java_default_link_name }}"
       when: filecheck and filecheck.stat.exists
 
+  become: yes
   when: ansible_os_family != "Darwin"
 
 

--- a/tasks/use-tarball.yml
+++ b/tasks/use-tarball.yml
@@ -12,6 +12,7 @@
     owner: root
     group: root
     mode: "u=rwx,go=rx"
+  become: yes
 
 - name: install JDK via tarball file
   unarchive:
@@ -21,3 +22,4 @@
     group: root
     mode: "go-w"
     copy: no
+  become: yes


### PR DESCRIPTION
The role works fine when running as root. On AWS Lightsail, that's not an option. Adding `become` to escalate for directory creation, tar unarchiving, and the symlinks for alternatives.