### PR TITLE
Add support for DNF-powered distros

### DIFF
--- a/tasks/set-platform-vars.yml
+++ b/tasks/set-platform-vars.yml
@@ -30,7 +30,7 @@
     use_tarball: false
     use_dmg: false
     install_file_extension: rpm
-  when: (ansible_pkg_mgr == "yum" or ansible_pkg_mgr == "zypper") and ansible_os_family != 'Darwin'
+  when: (ansible_pkg_mgr == "yum" or ansible_pkg_mgr == "dnf" or ansible_pkg_mgr == "zypper") and ansible_os_family != 'Darwin'
 
 - name: Set Gzipped Tarball binary
   set_fact:
@@ -38,7 +38,7 @@
     use_rpm: false
     use_dmg: false
     install_file_extension: tar.gz
-  when: ansible_pkg_mgr != "yum" and ansible_pkg_mgr != "zypper" and ansible_os_family != "Darwin"
+  when: ansible_pkg_mgr != "yum" and ansible_pkg_mgr != "dnf" and ansible_pkg_mgr != "zypper" and ansible_os_family != "Darwin"
 
 - name: Set dmg binary
   set_fact:
@@ -46,4 +46,4 @@
     use_rpm: false
     use_tarball: false
     install_file_extension: dmg
-  when: ansible_pkg_mgr != "yum" and ansible_pkg_mgr != "zypper" and ansible_os_family == "Darwin"
+  when: ansible_pkg_mgr != "yum" and ansible_pkg_mgr != "dnf" and ansible_pkg_mgr != "zypper" and ansible_os_family == "Darwin"

--- a/tasks/use-rpm.yml
+++ b/tasks/use-rpm.yml
@@ -17,7 +17,7 @@
     name: "{{ java_download_path }}/{{ jdk_file_name }}.{{ install_file_extension }}"
     state: present
   become: true
-  when: ansible_pkg_mgr == "yum"
+  when: ansible_pkg_mgr == "yum" or ansible_pkg_mgr == "dnf"
 
 - block:
     - name: Symlink /usr/sbin/update-alternatives to /usr/sbin/alternatives


### PR DESCRIPTION
Distributions like CentOS 8 use dnf as their package manager, which is why this role did not work correctly there. This fixes it.